### PR TITLE
Initial launch behaviors & crash fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace

--- a/FreshAir/RZFReleaseNotes.h
+++ b/FreshAir/RZFReleaseNotes.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) NSArray<RZFRelease *> *releases;
 @property (strong, nonatomic) NSURL *upgradeURL;
-@property (strong, nonatomic) NSString * __nullable minimumVersion;
+@property (strong, nonatomic, nullable) NSString *minimumVersion;
 @property (strong, nonatomic, readonly) NSArray<RZFFeature *> *features;
 
 - (BOOL)isUpgradeRequiredForVersion:(NSString *)version;

--- a/FreshAir/RZFReleaseNotes.m
+++ b/FreshAir/RZFReleaseNotes.m
@@ -29,6 +29,13 @@
             [self.minimumVersion compare:version options:NSNumericSearch] == NSOrderedDescending);
 }
 
+- (void)setReleases:(NSArray<RZFRelease *> *)releases
+{
+    _releases = [releases sortedArrayUsingComparator:^NSComparisonResult(RZFRelease *release1, RZFRelease *release2) {
+        return [release1.version compare:release2.version options:NSNumericSearch];
+    }];
+}
+
 - (NSArray *)features
 {
     NSMutableArray *features = [NSMutableArray array];

--- a/FreshAir/RZFReleaseNotesCheck.m
+++ b/FreshAir/RZFReleaseNotesCheck.m
@@ -28,10 +28,12 @@
 {
     if ([self.releaseNoteURL isFileURL]) {
         NSError *error = nil;
+
         RZFReleaseNotes *releaseNotes = [RZFReleaseNotes releaseNotesWithURL:self.releaseNoteURL error:&error];
         if (error) {
             NSLog(@"%@", error);
         }
+
         [self checkReleaseNotes:releaseNotes completion:completion];
     }
     else {
@@ -65,7 +67,7 @@
         lastVersion = [lastRelease version];
         upgradeURL = releaseNotes.upgradeURL;
 
-        BOOL newVersion  = [self.appVersion compare:lastVersion options:NSNumericSearch] == NSOrderedAscending;
+        BOOL newVersion = [self.appVersion compare:lastVersion options:NSNumericSearch] == NSOrderedAscending;
         BOOL deviceSupported = lastVersion != nil;
         if (newVersion && deviceSupported) {
             status = RZFAppUpdateStatusNewVersion;

--- a/FreshAir/RZFReleaseNotesCheck.m
+++ b/FreshAir/RZFReleaseNotesCheck.m
@@ -26,7 +26,7 @@
 
 - (void)performCheckWithCompletion:(RZFAppUpdateCheckCompletion)completion;
 {
-    if ([self.releaseNoteURL.scheme isEqual:@"file"]) {
+    if ([self.releaseNoteURL isFileURL]) {
         NSError *error = nil;
         RZFReleaseNotes *releaseNotes = [RZFReleaseNotes releaseNotesWithURL:self.releaseNoteURL error:&error];
         if (error) {

--- a/FreshAir/RZFReleaseNotesCheck.m
+++ b/FreshAir/RZFReleaseNotesCheck.m
@@ -35,12 +35,18 @@
         [self checkReleaseNotes:releaseNotes completion:completion];
     }
     else {
-        NSURLSessionDataTask *task = [self.session dataTaskWithURL:self.releaseNoteURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-            NSError *importError = nil;
-            RZFReleaseNotes *releaseNotes = [RZFReleaseNotes releaseNotesWithData:data error:&importError];
-            if (importError || error) {
-                NSLog(@"%@", importError ?: error);
+        NSURLSessionDataTask *task = [self.session dataTaskWithURL:self.releaseNoteURL completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response, NSError *_Nullable error) {
+            NSError *importError;
+            RZFReleaseNotes *releaseNotes;
+
+            if (data) {
+                releaseNotes = [RZFReleaseNotes releaseNotesWithData:data error:&importError];
             }
+
+            if (importError || !releaseNotes) {
+                NSLog(@"request for version history failed: %@", importError ?: error);
+            }
+
             [self checkReleaseNotes:releaseNotes completion:completion];
         }];
         [task resume];

--- a/FreshAir/RZFUpgradeManager.m
+++ b/FreshAir/RZFUpgradeManager.m
@@ -89,7 +89,7 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
         BOOL newVersion = (status == RZFAppUpdateStatusNewVersion);
         BOOL isForced = (status == RZFAppUpdateStatusNewVersionForced);
         NSString *lastDisplayed = [self.userDefaults stringForKey:RZFLastVersionPromptedKey];
-        BOOL newUnseenVersion = [self.appVersion compare:lastDisplayed options:NSNumericSearch] == NSOrderedAscending;
+        BOOL newUnseenVersion = ((lastDisplayed == nil) || ([self.appVersion compare:lastDisplayed options:NSNumericSearch] == NSOrderedAscending));
         BOOL shouldDisplay = ((newVersion && newUnseenVersion) || isForced);
         if (shouldDisplay) {
             RZFUpdatePromptViewController *vc = nil;
@@ -98,6 +98,8 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
                                                                   isForced:isForced];
             vc.delegate = self;
             [self.delegate rzf_interationDelegate:self presentViewController:vc];
+
+            [self.userDefaults setObject:self.appVersion forKey:RZFLastVersionPromptedKey];
         }
     }];
 }
@@ -109,7 +111,6 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
 
 - (void)dismissUpdatePromptViewController:(RZFUpdatePromptViewController *)updatePromptViewController
 {
-    [self.userDefaults setObject:self.appVersion forKey:RZFLastVersionPromptedKey];
     [self.delegate rzf_interationDelegate:self dismissViewController:updatePromptViewController];
 }
 

--- a/FreshAir/RZFUpgradeManager.m
+++ b/FreshAir/RZFUpgradeManager.m
@@ -131,12 +131,7 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
     }
 
     NSString *lastVersion = [self.userDefaults stringForKey:RZFLastVersionOfReleaseNotesDisplayedKey];
-    
-    // If this is our first run through and we haven't shown any release notes yet,
-    //  show all the notes from the first version on.
-    lastVersion = lastVersion ?: releaseNotes.releases.firstObject.version;
-
-    if ([self.appVersion compare:lastVersion options:NSNumericSearch] == NSOrderedDescending) {
+    if ((lastVersion != nil) && ([self.appVersion compare:lastVersion options:NSNumericSearch] == NSOrderedDescending)) {
         NSArray *features = [releaseNotes featuresFromVersion:lastVersion toVersion:self.appVersion];
 
         RZFReleaseNotesViewController *vc = [[RZFReleaseNotesViewController alloc] initWithFeatures:features];

--- a/FreshAir/RZFUpgradeManager.m
+++ b/FreshAir/RZFUpgradeManager.m
@@ -18,13 +18,12 @@
 #import "RZFReleaseNotesViewController.h"
 
 // Keys for tracking state in NSUserDefaults
-NSString *const RZFLastVersionPromptedKey = @"RZFLastVersionPromptedKey";
-NSString *const RZFLastVersionOfReleaseNotesDisplayedKey = @"RZFLastVersionOfReleaseNotesDisplayedKey";
+static NSString *const RZFLastVersionPromptedKey = @"RZFLastVersionPromptedKey";
+static NSString *const RZFLastVersionOfReleaseNotesDisplayedKey = @"RZFLastVersionOfReleaseNotesDisplayedKey";
 static NSString *const RZFReleaseNotesResourceName = @"release_notes";
 static NSString *const RZFReleaseNotesResourceExtension = @"json";
 
-@interface RZFUpgradeManager ()
-<RZFUpdatePromptViewControllerDelegate, RZFReleaseNotesViewControllerDelegate>
+@interface RZFUpgradeManager () <RZFUpdatePromptViewControllerDelegate, RZFReleaseNotesViewControllerDelegate>
 
 @property (strong, nonatomic, readonly) NSURL *releaseNoteURL;
 @property (strong, nonatomic, readonly) NSString *appStoreID;
@@ -72,6 +71,7 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
 - (void)checkForNewUpdate
 {
     RZFReleaseNotesCheck *check = nil;
+
     if (self.appStoreID) {
         // RZFAppStoreUpdateCheck has the same contract as RZFAppUpdateCheck.
         // RZFAppStoreUpdateCheck was written to be isolated from the rest of the
@@ -82,9 +82,10 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
     }
     else {
         check = [[RZFReleaseNotesCheck alloc] initWithReleaseNoteURL:self.releaseNoteURL
-                                                      appVersion:self.appVersion
-                                                    systemVersion:self.systemVersion];
+                                                          appVersion:self.appVersion
+                                                       systemVersion:self.systemVersion];
     }
+
     [check performCheckWithCompletion:^(RZFAppUpdateStatus status, NSString *version, NSURL *upgradeURL) {
         BOOL newVersion = (status == RZFAppUpdateStatusNewVersion);
         BOOL isForced = (status == RZFAppUpdateStatusNewVersionForced);


### PR DESCRIPTION
- There should be a gitignore
- Releases should be sorted by version number before being used
- On the initial launch, if there is an update available the user should be prompted to update
- On the initial launch, the user should be shown all new features from their current version on.
- If the version history fails to load, the app should not crash
