### PR TITLE
There should be an option for force the initial release note display.

### DIFF
--- a/FreshAir/RZFUpgradeManager.h
+++ b/FreshAir/RZFUpgradeManager.h
@@ -70,24 +70,31 @@
 /**
  * Present the release notes if there are features that the current user has not seen.
  * This should be called when the app finishes launching. If the app is being launched
- * for the first time, the release notes will not be displayed.
+ * for the first time, the release notes will not be displayed. When this method is called,
+ * the current app version will be saved to the user defaults.
+ *
+ * @see showNewReleaseNotes:
  */
 - (void)showNewReleaseNotes;
 
 /**
  * Present the release notes if there are features that the current user has not seen.
- * This should be called when the app finishes launching.
+ * This should be called when the app finishes launching. When this method is called,
+ * the current app version will be saved to the user defaults.
  *
- * The default behavior is to skip the display of the release notes on the first launch.
- * Passing YES allows that behavior to be overridden. If the initial display is forced,
- * all release notes from the first version up to the current app version will be displayed.
+ * The default behavior is to display release notes if the last saved version is
+ * less than the current version. If this method has never been called, there will be no
+ * saved version, and the release notes will not be displayed. This behavior can be
+ * changed to display the release notes if there is no saved version by setting
+ * forceInitialDisplay to YES.
  *
  * @param forceInitialDisplay YES if the release notes should be displayed on initial launch
  */
 - (void)showNewReleaseNotes:(BOOL)forceInitialDisplay;
 
 /**
- *  Reset any stored keys in the user defaults.
+ *  Reset any saved keys in the user defaults.
+ *
  */
 - (void)resetViewedState;
 

--- a/FreshAir/RZFUpgradeManager.h
+++ b/FreshAir/RZFUpgradeManager.h
@@ -69,8 +69,22 @@
 
 /**
  * Present the release notes if there are features that the current user has not seen.
+ * This should be called when the app finishes launching. If the app is being launched
+ * for the first time, the release notes will not be displayed.
  */
 - (void)showNewReleaseNotes;
+
+/**
+ * Present the release notes if there are features that the current user has not seen.
+ * This should be called when the app finishes launching.
+ *
+ * The default behavior is to skip the display of the release notes on the first launch.
+ * Passing YES allows that behavior to be overridden. If the initial display is forced,
+ * all release notes from the first version up to the current app version will be displayed.
+ *
+ * @param forceInitialDisplay YES if the release notes should be displayed on initial launch
+ */
+- (void)showNewReleaseNotes:(BOOL)forceInitialDisplay;
 
 /**
  *  Reset any stored keys in the user defaults.

--- a/FreshAir/RZFUpgradeManager.m
+++ b/FreshAir/RZFUpgradeManager.m
@@ -117,9 +117,14 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
 
 - (void)showNewReleaseNotes
 {
+    [self showNewReleaseNotes:NO];
+}
+
+- (void)showNewReleaseNotes:(BOOL)forceInitialDisplay
+{
     NSURL *releaseURL = [self.releaseNoteBundle URLForResource:RZFReleaseNotesResourceName withExtension:RZFReleaseNotesResourceExtension];
     if (!releaseURL) {
-        NSLog(@"failed to load the '%@.%@' from bundle %@", RZFReleaseNotesResourceName, RZFReleaseNotesResourceExtension, self.releaseNoteBundle.bundleIdentifier);
+        NSLog(@"failed to load '%@.%@' from bundle %@", RZFReleaseNotesResourceName, RZFReleaseNotesResourceExtension, self.releaseNoteBundle.bundleIdentifier);
         return;
     }
 
@@ -131,6 +136,10 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
     }
 
     NSString *lastVersion = [self.userDefaults stringForKey:RZFLastVersionOfReleaseNotesDisplayedKey];
+    if (forceInitialDisplay && (lastVersion == nil)) {
+        lastVersion = releaseNotes.releases.firstObject.version;
+    }
+
     if ((lastVersion != nil) && ([self.appVersion compare:lastVersion options:NSNumericSearch] == NSOrderedDescending)) {
         NSArray *features = [releaseNotes featuresFromVersion:lastVersion toVersion:self.appVersion];
 


### PR DESCRIPTION
In certain situations, the developer will want to present the release notes for the current version on the initial launch of the app.
