### PR TITLE
Fixes for modal presentation and update states

### DIFF
--- a/FreshAir/RZFReleaseNotesCheck.m
+++ b/FreshAir/RZFReleaseNotesCheck.m
@@ -70,7 +70,8 @@
         BOOL newVersion = [self.appVersion compare:lastVersion options:NSNumericSearch] == NSOrderedAscending;
         BOOL deviceSupported = lastVersion != nil;
         if (newVersion && deviceSupported) {
-            status = RZFAppUpdateStatusNewVersion;
+            BOOL updateIsForced = [self.appVersion compare:releaseNotes.minimumVersion options:NSNumericSearch] == NSOrderedAscending;
+            status = updateIsForced ? RZFAppUpdateStatusNewVersionForced : RZFAppUpdateStatusNewVersion;
         }
         else if (newVersion && deviceSupported == NO) {
             status = RZFAppUpdateStatusNewVersionUnsupportedOnDevice;

--- a/FreshAir/RZFReleaseNotesCheck.m
+++ b/FreshAir/RZFReleaseNotesCheck.m
@@ -69,9 +69,13 @@
 
         BOOL newVersion = [self.appVersion compare:lastVersion options:NSNumericSearch] == NSOrderedAscending;
         BOOL deviceSupported = lastVersion != nil;
-        if (newVersion && deviceSupported) {
-            BOOL updateIsForced = [self.appVersion compare:releaseNotes.minimumVersion options:NSNumericSearch] == NSOrderedAscending;
-            status = updateIsForced ? RZFAppUpdateStatusNewVersionForced : RZFAppUpdateStatusNewVersion;
+        BOOL updateIsForced = [self.appVersion compare:releaseNotes.minimumVersion options:NSNumericSearch] == NSOrderedAscending;
+
+        if (updateIsForced) {
+            status = RZFAppUpdateStatusNewVersionForced;
+        }
+        else if (newVersion && deviceSupported) {
+            status = RZFAppUpdateStatusNewVersion;
         }
         else if (newVersion && deviceSupported == NO) {
             status = RZFAppUpdateStatusNewVersionUnsupportedOnDevice;

--- a/FreshAir/RZFUpgradeManager.m
+++ b/FreshAir/RZFUpgradeManager.m
@@ -93,6 +93,11 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
         NSString *lastDisplayed = [self.userDefaults stringForKey:RZFLastVersionPromptedKey];
         BOOL newUnseenVersion = ((lastDisplayed == nil) || ([self.appVersion compare:lastDisplayed options:NSNumericSearch] == NSOrderedAscending));
         BOOL shouldDisplay = ((newVersion && newUnseenVersion) || isForced);
+
+        // The handling of the RZFAppUpdateStatusNewVersionUnsupportedOnDevice state is implicit here.
+        // If the update is forced, we show the user the forced update screen no matter what (ignoring
+        // if the device is supported or not). If there is an update, but it's not supported, we ignore
+        // state and just don't show the user anything.
         if (shouldDisplay) {
             // Check to see if something other than the update prompt is being presented at the moment.
             if ([self.presentedViewController isKindOfClass:[RZFUpdatePromptViewController class]]) {

--- a/FreshAir/RZFUpgradeManager.m
+++ b/FreshAir/RZFUpgradeManager.m
@@ -100,6 +100,10 @@ static NSString *const RZFReleaseNotesResourceExtension = @"json";
         // state and just don't show the user anything.
         if (shouldDisplay) {
             // Check to see if something other than the update prompt is being presented at the moment.
+            // This introduces some oddities into the RZFInteractionDelegate contract which needs to be
+            // resolved at some point in the future. This logic should be moved into the default
+            // implementation and not exist here in case the consumer's delegate wants a differing
+            // presentation method.
             if ([self.presentedViewController isKindOfClass:[RZFUpdatePromptViewController class]]) {
                 // If we are already showing an update prompt, bail. There's nothing left to do.
                 return;


### PR DESCRIPTION
- Multiple modal view controllers should not be presented simultaneously
- If the current version is below the minimum version, the update should be forced
