### PR TITLE
Add support for forced-update localization

### DIFF
--- a/FreshAir/UI/RZFUpdateViewModel.h
+++ b/FreshAir/UI/RZFUpdateViewModel.h
@@ -13,13 +13,12 @@
 @interface RZFUpdateViewModel : NSObject
 
 - (instancetype)init;
-
-@property (copy, nonatomic) NSString *localizedTitle;
-@property (copy, nonatomic) NSString *localizedDescription;
-@property (strong, nonatomic) UIImage *image;
-
-@property (copy, nonatomic) NSString *localizedConfirmation;
-@property (copy, nonatomic) NSString *localizedDismiss;
 @property (assign, nonatomic) BOOL isForced;
+
+@property (strong, nonatomic, readonly) UIImage *image;
+@property (copy, nonatomic, readonly) NSString *localizedTitle;
+@property (copy, nonatomic, readonly) NSString *localizedDescription;
+@property (copy, nonatomic, readonly) NSString *localizedConfirmation;
+@property (copy, nonatomic, readonly) NSString *localizedDismiss;
 
 @end

--- a/FreshAir/UI/RZFUpdateViewModel.m
+++ b/FreshAir/UI/RZFUpdateViewModel.m
@@ -19,23 +19,23 @@ static NSString * const RZFUpdateViewModelLocalizedKeyDescription = @"descriptio
 static NSString * const RZFUpdateViewModelLocalizedKeyConfirm = @"confirm";
 static NSString * const RZFUpdateViewModelLocalizedKeyDismiss = @"dismiss";
 
-static NSString *RZFLocalizedValue(NSString * _Nonnull prefix, NSString * _Nonnull key, NSBundle * _Nullable fallbackBundle, NSString * _Nullable fallbackTableName) {
-    NSString *notFoundToken = @"RZFKeyNotFound";
+static NSString *RZFLocalizedValue(NSString * _Nonnull prefix, NSString * _Nonnull key, NSBundle * _Nullable fallbackBundle) {
+    static NSString * const notFoundToken = @"RZFKeyNotFound";
+    
     NSString *fullKey = [@[prefix,key] componentsJoinedByString:@"."];
     NSBundle *mainBundle = [NSBundle mainBundle];
-    BOOL hasFallbackTableName = (fallbackTableName.length > 0);
     
     NSString *localizedValue = [mainBundle localizedStringForKey:fullKey value:notFoundToken table:nil];
     
-    if ([localizedValue isEqualToString:notFoundToken] && hasFallbackTableName) {
-        localizedValue = [mainBundle localizedStringForKey:fullKey value:notFoundToken table:fallbackTableName];
+    if ([localizedValue isEqualToString:notFoundToken]) {
+        localizedValue = [mainBundle localizedStringForKey:fullKey value:notFoundToken table:RZFUpdateViewModelStringTableName];
     }
     
     if ([localizedValue isEqualToString:notFoundToken] && fallbackBundle) {
         NSString *fallbackLocalizedValue = [fallbackBundle localizedStringForKey:fullKey value:notFoundToken table:nil];
         
-        if ([fallbackLocalizedValue isEqualToString:notFoundToken] && hasFallbackTableName) {
-            fallbackLocalizedValue = [fallbackBundle localizedStringForKey:fullKey value:notFoundToken table:fallbackTableName];
+        if ([fallbackLocalizedValue isEqualToString:notFoundToken]) {
+            fallbackLocalizedValue = [fallbackBundle localizedStringForKey:fullKey value:notFoundToken table:RZFUpdateViewModelStringTableName];
         }
         
         localizedValue = fallbackLocalizedValue;
@@ -55,7 +55,7 @@ static NSString *RZFLocalizedValue(NSString * _Nonnull prefix, NSString * _Nonnu
 {
     self = [super init];
     if (self) {
-        
+        /* Do Nothing */
     }
    
     return self;
@@ -95,22 +95,17 @@ static NSString *RZFLocalizedValue(NSString * _Nonnull prefix, NSString * _Nonnu
 
 #pragma  mark - Private
 
-- (NSString*)localizedKeyPrefix
-{
-    return self.isForced ? RZFUpdateViewModelForcedUpdatePrefix : RZFUpdateViewModelUpdatePrefix;
-}
-
 - (NSString*)localizedValueForKey:(NSString*)key
 {
     NSString *localizedValue = nil;
     NSBundle *fallbackBundle = [NSBundle bundleForClass:self.class];
     
     if (self.isForced) {
-        localizedValue = RZFLocalizedValue(RZFUpdateViewModelForcedUpdatePrefix, key, fallbackBundle, RZFUpdateViewModelStringTableName);
+        localizedValue = RZFLocalizedValue(RZFUpdateViewModelForcedUpdatePrefix, key, fallbackBundle);
     }
     
     if (!localizedValue) {
-        localizedValue = RZFLocalizedValue(RZFUpdateViewModelUpdatePrefix, key, fallbackBundle, RZFUpdateViewModelStringTableName);
+        localizedValue = RZFLocalizedValue(RZFUpdateViewModelUpdatePrefix, key, fallbackBundle);
     }
     
     return localizedValue;

--- a/FreshAir/UI/RZFUpdateViewModel.m
+++ b/FreshAir/UI/RZFUpdateViewModel.m
@@ -9,16 +9,44 @@
 #import "RZFUpdateViewModel.h"
 #import "RZFReleaseNotes.h"
 
-static NSString *RZFLocalizedValue(NSBundle *bundle, NSString *key) {
-    NSString *fullKey = [@"freshair.update." stringByAppendingString:key];
-    NSString *value = [[NSBundle mainBundle] localizedStringForKey:fullKey value:nil table:@"FreshAirUpdate"];
-    if ([value isEqual:fullKey]) {
-        value = [[NSBundle mainBundle] localizedStringForKey:fullKey value:nil table:nil];
+static NSString * const RZFUpdateViewModelForcedUpdatePrefix = @"freshair.update.forced";
+static NSString * const RZFUpdateViewModelUpdatePrefix = @"freshair.update";
+static NSString * const RZFUpdateViewModelStringTableName = @"FreshAirUpdate";
+static NSString * const RZFUpdateViewModelUpdateImageName = @"freshair_update";
+
+static NSString * const RZFUpdateViewModelLocalizedKeyTitle = @"title";
+static NSString * const RZFUpdateViewModelLocalizedKeyDescription = @"description";
+static NSString * const RZFUpdateViewModelLocalizedKeyConfirm = @"confirm";
+static NSString * const RZFUpdateViewModelLocalizedKeyDismiss = @"dismiss";
+
+static NSString *RZFLocalizedValue(NSString * _Nonnull prefix, NSString * _Nonnull key, NSBundle * _Nullable fallbackBundle, NSString * _Nullable fallbackTableName) {
+    NSString *notFoundToken = @"RZFKeyNotFound";
+    NSString *fullKey = [@[prefix,key] componentsJoinedByString:@"."];
+    NSBundle *mainBundle = [NSBundle mainBundle];
+    BOOL hasFallbackTableName = (fallbackTableName.length > 0);
+    
+    NSString *localizedValue = [mainBundle localizedStringForKey:fullKey value:notFoundToken table:nil];
+    
+    if ([localizedValue isEqualToString:notFoundToken] && hasFallbackTableName) {
+        localizedValue = [mainBundle localizedStringForKey:fullKey value:notFoundToken table:fallbackTableName];
     }
-    if ([value isEqual:fullKey]) {
-        value = [bundle localizedStringForKey:fullKey value:nil table:@"FreshAirUpdate"];
+    
+    if ([localizedValue isEqualToString:notFoundToken] && fallbackBundle) {
+        NSString *fallbackLocalizedValue = [fallbackBundle localizedStringForKey:fullKey value:notFoundToken table:nil];
+        
+        if ([fallbackLocalizedValue isEqualToString:notFoundToken] && hasFallbackTableName) {
+            fallbackLocalizedValue = [fallbackBundle localizedStringForKey:fullKey value:notFoundToken table:fallbackTableName];
+        }
+        
+        localizedValue = fallbackLocalizedValue;
     }
-    return value;
+    
+    if ([localizedValue isEqualToString:notFoundToken]) {
+        NSLog(@"failed to find localized value for key %@", fullKey);
+        localizedValue = nil;
+    }
+    
+    return localizedValue;
 }
 
 @implementation RZFUpdateViewModel
@@ -27,18 +55,65 @@ static NSString *RZFLocalizedValue(NSBundle *bundle, NSString *key) {
 {
     self = [super init];
     if (self) {
-        NSBundle *fallbackBundle = [NSBundle bundleForClass:self.class];
-        self.image = [UIImage imageNamed:@"freshair_update" inBundle:fallbackBundle compatibleWithTraitCollection:nil];
-        if (self.image == nil) {
-            self.image = [UIImage imageNamed:@"freshair_update"];
-        }
-        self.localizedTitle = RZFLocalizedValue(fallbackBundle, @"title");
-        self.localizedDescription = RZFLocalizedValue(fallbackBundle, @"description");
-        self.localizedDismiss = RZFLocalizedValue(fallbackBundle, @"dismiss");
-        self.localizedConfirmation = RZFLocalizedValue(fallbackBundle, @"confirm");
+        
     }
    
     return self;
+}
+
+- (UIImage*)image
+{
+    UIImage *image = [UIImage imageNamed:RZFUpdateViewModelUpdateImageName];
+    
+    if (!image) {
+        NSBundle *fallbackBundle = [NSBundle bundleForClass:self.class];
+        image = [UIImage imageNamed:RZFUpdateViewModelUpdateImageName inBundle:fallbackBundle compatibleWithTraitCollection:nil];
+    }
+    
+    return image;
+}
+
+- (NSString*)localizedTitle
+{
+    return [self localizedValueForKey:RZFUpdateViewModelLocalizedKeyTitle];
+}
+
+- (NSString*)localizedDescription
+{
+    return [self localizedValueForKey:RZFUpdateViewModelLocalizedKeyDescription];
+}
+
+- (NSString*)localizedDismiss
+{
+    return [self localizedValueForKey:RZFUpdateViewModelLocalizedKeyDismiss];
+}
+
+- (NSString*)localizedConfirmation
+{
+    return [self localizedValueForKey:RZFUpdateViewModelLocalizedKeyConfirm];
+}
+
+#pragma  mark - Private
+
+- (NSString*)localizedKeyPrefix
+{
+    return self.isForced ? RZFUpdateViewModelForcedUpdatePrefix : RZFUpdateViewModelUpdatePrefix;
+}
+
+- (NSString*)localizedValueForKey:(NSString*)key
+{
+    NSString *localizedValue = nil;
+    NSBundle *fallbackBundle = [NSBundle bundleForClass:self.class];
+    
+    if (self.isForced) {
+        localizedValue = RZFLocalizedValue(RZFUpdateViewModelForcedUpdatePrefix, key, fallbackBundle, RZFUpdateViewModelStringTableName);
+    }
+    
+    if (!localizedValue) {
+        localizedValue = RZFLocalizedValue(RZFUpdateViewModelUpdatePrefix, key, fallbackBundle, RZFUpdateViewModelStringTableName);
+    }
+    
+    return localizedValue;
 }
 
 @end


### PR DESCRIPTION
Add support for 'freshair.update.forced._' variants of the 'freshair.update._' strings. If the forced update keys are not present, the update screen will fallback to the previous behavior and show the `freshair.update.*` values.
